### PR TITLE
Add optional amount parameter to get_followers method via -fa or --followersamount flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 driver
 .env
 env
+venv

--- a/instafunc.py
+++ b/instafunc.py
@@ -372,7 +372,7 @@ class Insta:
         username = username.split('/')[1]
         return username
 
-    def get_followers(self) -> List:
+    def get_followers(self, amount: int = None) -> List:
         """
         Gets followers from the target's page
         This function is still under development - DO NOT USE
@@ -392,7 +392,9 @@ class Insta:
 
         time.sleep(3)
 
-        while(num_updated_div > num_previous_div):    
+        running = True
+
+        while(num_updated_div > num_previous_div and running):    
 
             logger.info('Getting updated list of username divs')
             username_links = None
@@ -435,6 +437,11 @@ class Insta:
                 # add found username to the list
                 if username and username not in usernames:
                     usernames.append(username)
+
+                # check if we have reached the desired amount
+                if amount is not None and len(usernames) >= amount:
+                    running = False
+                    break
                     
             logger.info(f'Total username count: {len(usernames)}')
             logger.info('Scrolling')

--- a/instalikecombot.py
+++ b/instalikecombot.py
@@ -85,6 +85,7 @@ parser.add_argument('-t', '--target',  metavar='', type=str, help='target (accou
 parser.add_argument('-np', '--numofposts', type=int, metavar='', help='number of posts to like')
 parser.add_argument('-ps', '--postscript', type=str, metavar='', help='additional text to add after every comment')
 parser.add_argument('-ff', '--findfollowers', action='store_true', help="like/comment on posts from target's followers")
+parser.add_argument('-fa', '--followersamount', type=int, metavar='', help='number of followers to process (default=all)', default=None)
 
 parser.add_argument('-mt', '--matchtags', type=str, metavar='', help='read tags to match from a file')
 match_group = parser.add_mutually_exclusive_group()
@@ -209,7 +210,7 @@ try:
         raise Exception(f"Invalid tag or account : {TARGET}")
     
     if args.findfollowers:
-        followers = insta.get_followers()
+        followers = insta.get_followers(args.followersamount)
         logger.info(followers)
         logger.info(f'Found {len(followers)} followers')
         target_list = followers


### PR DESCRIPTION
This pull request introduces an optional amount parameter to the get_followers method, allowing users to limit the number of returned followers using the -fa [number] or --followersamount [number] command-line flag.